### PR TITLE
Specify word rotation angle

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -69,6 +69,7 @@ options = {
 	settings: {
 		minFontSize: 10,
 		maxFontSize: 100,
+		textRotation: 0 // see below
 	},
 	margin: {
 		top: 10,
@@ -86,9 +87,13 @@ options = {
 - `wordData` (`Array<WordCloudData> | WordCloudData[]`) -  set of words, it should be `Array<WordCloudData>` and each object must have a `text` and `size`;
 - `colors` (`?Array<string> | string[]`) - data colors, will use default and|or random colors if not specified.
 - `options` (`?WordCloudOptions`) - word cloud options and there are two object you can pass it `settings` and `margin`.
-    - `setting` containes `minFontSize` and `maxFontSize` for word sets.
-    - `margin` of canves `top, left, bottom, right`, Default values is 10.
-    - `labels` show Size label at the bottom
+    * `settings`
+			- `minFontSize`
+			- `maxFontSize`
+			- `textRotation` (`?number | RotationFunction`):
+				accepts a number (angle) which all words in the cloud will be rotated at (ie 0 means no rotation). Alternatively a function can be passed which returns a number (to be called on each word in the cloud)
+    * `margin` of canvas `top, left, bottom, right`, Default values is 10.
+    * `labels` show Size label at the bottom
 
 - `width` and `height` of canvas, the Default value for width is the width of the container, and the height equals the width * 0.75.
 

--- a/src/ag-wordcloud.directive.ts
+++ b/src/ag-wordcloud.directive.ts
@@ -5,6 +5,8 @@ import * as D3 from 'd3';
 
 declare let d3: any;
 
+type RotationFunction = () => number;
+
 @Directive({selector: 'div[AgWordCloud]', exportAs: 'ag-word-cloud'})
 export class AgWordCloudDirective implements OnInit {
 
@@ -28,6 +30,17 @@ export class AgWordCloudDirective implements OnInit {
 
     ngOnInit() {
         this.update();
+    }
+
+    private getTextRotation():number | RotationFunction {
+        const defaultRotation = () => ~~(Math.random() * 2) * 90;
+        try {
+            return this.options.settings.hasOwnProperty("textRotation")
+            ? this.options.settings.textRotation
+            : defaultRotation;
+        } catch (err) {
+            return defaultRotation;
+        }
     }
 
     private roundNumber() {
@@ -101,7 +114,7 @@ export class AgWordCloudDirective implements OnInit {
             .size([this.width, this.height])
             .words(this.temp)
             .padding(5)
-            .rotate(() => (~~(Math.random() * 2) * 90))
+            .rotate(this.getTextRotation())
             .font(fontFace)
             .fontWeight(fontWeight)
             .fontSize(d => (d.size))
@@ -178,6 +191,7 @@ export interface AgWordCloudOptions {
         fontFace?: string,
         fontWeight?: string,
         spiral?: string,
+        textRotation?: number | RotationFunction
     };
     margin?: {
         top: number,

--- a/src/ag-wordcloud.directive.ts
+++ b/src/ag-wordcloud.directive.ts
@@ -5,7 +5,7 @@ import * as D3 from 'd3';
 
 declare let d3: any;
 
-type RotationFunction = () => number;
+export type RotationFunction = () => number;
 
 @Directive({selector: 'div[AgWordCloud]', exportAs: 'ag-word-cloud'})
 export class AgWordCloudDirective implements OnInit {


### PR DESCRIPTION
I created a `options.settings.textRotation` option which accepts a `number` (angle) as a parameter. All words in the word cloud will be rotated at this angle, ie a 0 angle means no rotation.

If `options.settings.textRotation` is not specified then the default (existing) rotation function is used.

Alternatively `options.settings.textRotation` can accept a function which returns a `number`. This function is called for each word in the cloud. 